### PR TITLE
Fix to MenuNode sort order break when label changes

### DIFF
--- a/Admin/MenuNodeAdmin.php
+++ b/Admin/MenuNodeAdmin.php
@@ -36,18 +36,7 @@ class MenuNodeAdmin extends \Symfony\Cmf\Bundle\MenuBundle\Admin\MenuNodeAdmin
                     )
                 )
             ->end()
-            ->getFormBuilder()
-            ->addEventListener(
-                FormEvents::SUBMIT,
-                function (FormEvent $event) {
-                    /** @var MenuNode $menuNode */
-                    $menuNode = $event->getData();
-                    if ($menuNode->getLabel()) {
-                        $slugify = Slugify::create();
-                        $menuNode->setName($slugify->slugify($menuNode->getLabel()));
-                    }
-                }
-            );
+        ;
     }
 
     protected function configureListFields(ListMapper $listMapper)

--- a/Document/MenuNode.php
+++ b/Document/MenuNode.php
@@ -32,6 +32,17 @@ class MenuNode extends \Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\MenuNode
     }
 
     /**
+     * @PHPCR\PrePersist
+     */
+    public function generateUniqidAsName()
+    {
+        if ($this->getName()) {
+            return;
+        }
+        $this->setName(uniqid());
+    }
+
+    /**
      * @return array
      */
     private function getParentPathComponents()

--- a/Tests/WebTest/DataFixtures/MenuNodeAdminTest/TwoPagesWithMenuNodesFixture.php
+++ b/Tests/WebTest/DataFixtures/MenuNodeAdminTest/TwoPagesWithMenuNodesFixture.php
@@ -1,0 +1,53 @@
+<?php
+
+
+namespace PUGX\Cmf\PageBundle\Tests\WebTest\DataFixtures\MenuNodeAdminTest;
+
+
+use Cocur\Slugify\Slugify;
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use PUGX\Cmf\PageBundle\Document\MenuNode;
+use PUGX\Cmf\PageBundle\Document\Page;
+
+class TwoPagesWithMenuNodesFixture implements FixtureInterface
+{
+    /**
+     * Load data fixtures with the passed EntityManager
+     *
+     * @param ObjectManager $manager
+     */
+    public function load(ObjectManager $manager)
+    {
+        $page = new Page();
+        $page->setTitle('Page 1');
+        $page->setText('Lorem ipsum dolor sit amet.');
+        $page->addMenuNode($this->createMenuNodeForPage('Page 1', $page, $manager));
+        $manager->persist($page);
+
+        $page = new Page();
+        $page->setTitle('Page 2');
+        $page->setText('Lorem ipsum dolor sit amet.');
+        $page->addMenuNode($this->createMenuNodeForPage('Page 2', $page, $manager));
+        $manager->persist($page);
+
+        $manager->flush();
+    }
+
+    /**
+     * @param $label
+     * @param $page
+     * @param ObjectManager $manager
+     * @return MenuNode
+     */
+    private function createMenuNodeForPage($label, $page, ObjectManager $manager)
+    {
+        $slugify = Slugify::create();
+        $menuNode = new MenuNode();
+        $menuNode->setName($slugify->slugify($label));
+        $menuNode->setLabel($label);
+        $menuNode->setContent($page);
+        $menuNode->setParentDocument($manager->find(null, '/cms/menu/main'));
+        return $menuNode;
+    }
+}

--- a/Tests/WebTest/MenuNodeAdminTest.php
+++ b/Tests/WebTest/MenuNodeAdminTest.php
@@ -1,0 +1,43 @@
+<?php
+
+
+namespace PUGX\Cmf\Tests\WebTest;
+
+
+use PUGX\Cmf\PageBundle\Test\IsolatedTestCase;
+
+class MenuNodeAdminTest extends IsolatedTestCase
+{
+    public function testChangeMenuLabelShouldNotChangeMenuNodeOrder()
+    {
+        $this->loadFixtures(
+            array('PUGX\Cmf\PageBundle\Tests\WebTest\DataFixtures\MenuNodeAdminTest\TwoPagesWithMenuNodesFixture')
+        );
+
+        $client = static::createClient();
+        $crawler = $client->request('GET', '/page-1');
+        $this->assertTrue($client->getResponse()->isSuccessful());
+        $mainMenu = $crawler->filter('nav#menu-main ul')->eq(0);
+        $this->assertCount(2, $mainMenu->filter('li'));
+        $this->assertContains('Page 1', $mainMenu->filter('li')->eq(0)->text());
+        $this->assertContains('Page 2', $mainMenu->filter('li')->eq(1)->text());
+
+        $crawler = $client->request('GET', '/admin/cmf/page/menunode/cms/menu/main/page-1/edit?uniqid=menu_node');
+        $editForm = $crawler->selectButton('Update')->form();
+        $editForm['menu_node[label]'] = 'Page 1 Edit';
+        $client->submit($editForm);
+        $this->assertTrue($client->getResponse()->isRedirect());
+        $crawler = $client->followRedirect();
+        $this->assertContains(
+            "Item \"Page 1 Edit\" has been successfully updated.",
+            $crawler->filter('.alert.alert-success')->text()
+        );
+
+        $crawler = $client->request('GET', '/page-1');
+        $this->assertTrue($client->getResponse()->isSuccessful());
+        $mainMenu = $crawler->filter('nav#menu-main ul')->eq(0);
+        $this->assertCount(2, $mainMenu->filter('li'));
+        $this->assertContains('Page 1', $mainMenu->filter('li')->eq(0)->text());
+        $this->assertContains('Page 2', $mainMenu->filter('li')->eq(1)->text());
+    }
+}

--- a/Tests/WebTest/PageAdminTest.php
+++ b/Tests/WebTest/PageAdminTest.php
@@ -9,6 +9,7 @@
 namespace PUGX\Cmf\Tests\WebTest;
 
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use PUGX\Cmf\PageBundle\Test\IsolatedTestCase;
 use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\DomCrawler\Crawler;
@@ -188,11 +189,13 @@ class PageAdminTest extends IsolatedTestCase
             'Lorem ipsum dolor',
             array(array('parent' => '/cms/menu/main', 'label' => 'Parent Page'))
         );
+        $client->request('GET', '/_cmf_tree/phpcr_odm_tree/children', array('root' => '/cms/menu/main'));
+        $mainMenuChildren = json_decode($client->getResponse()->getContent(), true);
         $this->createPage(
             $client,
             'Sub Page',
             'Lorem ipsum dolor',
-            array(array('parent' => '/cms/menu/main/parent-page', 'label' => 'Sub Page'))
+            array(array('parent' => $mainMenuChildren[0]['attr']['id'], 'label' => 'Sub Page'))
         );
         $this->goToPageListAndAssertData(
             $client,


### PR DESCRIPTION
The automatic node name for MenuNode generated from label's slug
caused a sort order break when the user wanted to change MenuNode
label. So, now MenuNode's node name is generated by a PrePersist
method which assigns a uniqid to newly persited MenuNodes.